### PR TITLE
Fixed prefix attack vector

### DIFF
--- a/command/text_command.go
+++ b/command/text_command.go
@@ -74,6 +74,12 @@ func (T *textCommand) Init() {
 }
 
 func (T *textCommand) ValidateArguments() bool {
+	// Don't allow commands that let the user choose a prefix
+	// IE "!badcomm $0$ this command is bad" could become "!badcomm /ban someinnocentguy this command is bad"
+	if strings.Index(T.response, "$0$") == 0 {
+		return false
+	}
+	
 	regex, err := regexp.Compile(`\$[0-9u]\$`)
 	if err != nil {
 		log.Fatalf("regex isn't supposed to error: %v", err)


### PR DESCRIPTION
Hey Jix,
This is a gotcha that we can prevent. When Jixbot is a moderator, commands with a leading $0$ can be used to do a number of privileged commands that we probably don't want users to be allowed to do such as purge/timeout/banning other users or exploiting another channel bot.

The goal of this change is to stop commands like this:
!addcommand !<name> $0$ <stuff>
from being added. I've seen commands like this happen before, always by mistake.

I'm assuming that T.response has the whitespace trimmed from the beginning. This probably isn't the optimal way to check a string prefix, but I don't know golang.